### PR TITLE
Corrected yaml indentation in Sigma regex rule

### DIFF
--- a/instructions/00-executive-demo.md
+++ b/instructions/00-executive-demo.md
@@ -333,20 +333,21 @@ Back in Gitpod, open Confluent Control Center by launching a new tab for port `9
     description: This rule is the regex rule test
     author: Mike Peacock
     logsource:
-    product: splunk
-    service: cisco:asa
+        product: splunk
+        service: cisco:asa
     detection:
-    filter_field:
-        sourcetype: cisco:asa
-    event_match:
-        event|re: '^(?<timestamp>\w{3}\s\d{2}\s\d{2}:\d{2}:\d{2})\s(?<hostname>[^\s]+)\s\%ASA-\d-(?<messageID>[^:]+):\s(?<action>[^\s]+)\s(?<protocol>[^\s]+)\ssrc\sinside:(?<src>[0-9\.]+)\/(?<srcport>[0-9]+)\sdst\soutside:(?<dest>[0-9\.]+)\/(?<destport>[0-9]+)'
-    condition: filter_field AND event_match
+        filter_field:
+            sourcetype: cisco:asa
+        event_match:
+            event|re: '^(?<timestamp>\w{3}\s\d{2}\s\d{2}:\d{2}:\d{2})\s(?<hostname>[^\s]+)\s\%ASA-\d-(?<messageID>[^:]+):\s(?<action>[^\s]+)\s(?<protocol>[^\s]+)\ssrc\sinside:(?<src>[0-9\.]+)\/(?<srcport>[0-9]+)\sdst\soutside:(?<dest>[0-9\.]+)\/(?<destport>[0-9]+)'
+        condition: filter_field AND event_match
     kafka: 
-    outputTopic: firewalls
-    customFields:
-        location: edge
-        sourcetype: cisco:asa
-        index: main
+        outputTopic: firewalls
+        customFields:
+            location: edge
+            sourcetype: cisco:asa
+            index: main
+
     ```
 
 > The source type here allows us to specify that we only want to run the extractions on a single type of record, which is more efficient than running regular expressions on every record. The regular expression field allows us to specify a pattern with capture groups that will get extracted into fields.


### PR DESCRIPTION
Without this change the rule won't submit if copied verbatim from the markdown - results in an NPE in the UI.

Possibly this code may need to be made null-safe too:

https://github.com/confluentinc/confluent-sigma/blob/531cef7f0efacfa4fe10ad6100d5571518e68799/sigma-parser/src/main/java/io/confluent/sigmarules/parsers/DetectionParser.java#L67

(`detections` is `null`).