### PR TITLE
Upgrade to Zeek 6.1.0, use zeek/zeek base Docker image, replace (archived) Metron Kafka plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,9 @@ services:
 
   # See https://github.com/berthayes/zeek-tcpreplay-kafka
   zeek-streamer:
-    image: wlaforest/zeek-tcpreplay-kafka:2.0
+    image: localbuild/zeek-tcpreplay-kafka
+    build:
+      context: images/zeek-tcpreplay-kafka
     platform: linux/amd64
     container_name: zeek-streamer
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,7 @@ services:
     volumes:
       - ./scripts/init_dummy.sh:/init_dummy.sh
       - ./zeek:/usr/local/zeek/share/zeek/site
+      - ./pcaps:/pcaps
     cap_add:
       - NET_ADMIN
 

--- a/images/zeek-tcpreplay-kafka/Dockerfile
+++ b/images/zeek-tcpreplay-kafka/Dockerfile
@@ -24,4 +24,5 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN zkg install --force seisollc/zeek-kafka --version v1.2.0 --user-var librdkafka_root=/usr && \
+    rm -rf /usr/local/zeek/var/lib/zkg/scratch /usr/local/zeek/var/lib/zkg/testing && \
     zeek -N Seiso::Kafka

--- a/images/zeek-tcpreplay-kafka/Dockerfile
+++ b/images/zeek-tcpreplay-kafka/Dockerfile
@@ -1,3 +1,8 @@
-FROM wlaforest/zeek-tcpreplay-kafka:1.0
-COPY zeek_streamer.pcap /pcaps/zeek_streamer.pcap
-COPY syslog.pcap /pcaps/syslog.pcap
+FROM zeek/zeek:6.1.0
+
+RUN apt-get update && \
+    apt-get install -y cmake libssl-dev librdkafka-dev libpcap-dev g++ tcpreplay && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN zkg install --force seisollc/zeek-kafka --version v1.2.0 --user-var librdkafka_root=/usr && \
+    zeek -N Seiso::Kafka

--- a/images/zeek-tcpreplay-kafka/Dockerfile
+++ b/images/zeek-tcpreplay-kafka/Dockerfile
@@ -1,7 +1,26 @@
 FROM zeek/zeek:6.1.0
 
 RUN apt-get update && \
-    apt-get install -y cmake libssl-dev librdkafka-dev libpcap-dev g++ tcpreplay && \
+    apt-get install -y \
+      bison \
+      clang \
+      cmake \
+      flex \
+      g++ \
+      gcc \
+      git \
+      iproute2 \
+      libssl-dev \
+      librdkafka-dev \
+      libpcap-dev \
+      make \
+      net-tools \
+      python3 \
+      softflowd \
+      swig \
+      tcpreplay \
+      zlib1g-dev \
+      && \
     rm -rf /var/lib/apt/lists/*
 
 RUN zkg install --force seisollc/zeek-kafka --version v1.2.0 --user-var librdkafka_root=/usr && \

--- a/scripts/init_dummy.sh
+++ b/scripts/init_dummy.sh
@@ -14,7 +14,7 @@ echo "Listen on dummy network with zeek packet sniffer"
 echo "Edit input syslog PCAP to simulate ssh attacks happening now"
 myether=$(ifconfig eth0 | grep ether | awk {'print $2'})
 mysubnet=$(ifconfig eth0 | grep 'inet ' | awk {'print $2'} | awk -F. {'print $1"."$2".0.0"'})
-connectip=$(python -c "import socket;addr1 = socket.gethostbyname('connect');s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.connect((addr1,8083));print(addr1)")
+connectip=$(python3 -c "import socket;addr1 = socket.gethostbyname('connect');s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.connect((addr1,8083));print(addr1)")
 connectmac=$(arp -a | grep connect | awk {'print $4'})
 input="/pcaps/syslog.pcap"
 output="/pcaps/edited_syslog.pcap"

--- a/zeek/local.zeek
+++ b/zeek/local.zeek
@@ -1,7 +1,11 @@
 ##! Local site policy. Customize as appropriate.
 ##!
 ##! This file will not be overwritten when upgrading or reinstalling!
-#
+
+# Installation-wide salt value that is used in some digest hashes, e.g., for
+# the creation of file IDs. Please change this to a hard to guess value.
+redef digest_salt = "Please change this value.";
+
 # This script logs which scripts were loaded during each run.
 @load misc/loaded-scripts
 
@@ -14,8 +18,10 @@
 # Enable logging of memory, packet and lag statistics.
 @load misc/stats
 
-# Load the scan detection script.
-@load misc/scan
+# For TCP scan detection, we recommend installing the package from
+# 'https://github.com/ncsa/bro-simple-scan'. E.g., by installing it via
+#
+#     zkg install ncsa/bro-simple-scan
 
 # Detect traceroute being run on the network. This could possibly cause
 # performance trouble when there are a lot of traceroutes on your network.
@@ -62,10 +68,6 @@
 # This script prevents the logging of SSL CA certificates in x509.log
 @load protocols/ssl/log-hostcerts-only
 
-# Uncomment the following line to check each SSL certificate hash against the ICSI
-# certificate notary service; see http://notary.icsi.berkeley.edu .
-# @load protocols/ssl/notary
-
 # If you have GeoIP support built in, do some geographic detections and
 # logging for SSH traffic.
 @load protocols/ssh/geo-data
@@ -88,9 +90,24 @@
 # Extend email alerting to include hostnames
 @load policy/frameworks/notice/extend-email/hostnames
 
+# Extend the notice.log with Community ID hashes
+# @load policy/frameworks/notice/community-id
+
+# Enable logging of telemetry data into telemetry.log and
+# telemetry_histogram.log.
+@load frameworks/telemetry/log
+
+# Enable metrics centralization on the manager. This opens port 9911/tcp
+# on the manager node that can be readily scraped by Prometheus.
+# @load frameworks/telemetry/prometheus
+
 # Uncomment the following line to enable detection of the heartbleed attack. Enabling
 # this might impact performance a bit.
 # @load policy/protocols/ssl/heartbleed
+
+# Uncomment the following line to enable logging of Community ID hashes in
+# the conn.log file.
+# @load policy/protocols/conn/community-id-logging
 
 # Uncomment the following line to enable logging of connection VLANs. Enabling
 # this adds two VLAN fields to the conn.log file.
@@ -99,9 +116,8 @@
 # Uncomment the following line to enable logging of link-layer addresses. Enabling
 # this adds the link-layer address for each connection endpoint to the conn.log file.
 # @load policy/protocols/conn/mac-logging
-#
-#
-@load policy/tuning/json-logs
+
+# Uncomment this to source zkg's package state
+# @load packages
 
 @load send-to-kafka
-#@load send-to-confluent-cloud

--- a/zeek/send-to-kafka.zeek
+++ b/zeek/send-to-kafka.zeek
@@ -1,5 +1,4 @@
-#@load packages/metron-bro-plugin-kafka
-@load Apache/Kafka
+@load Seiso/Kafka
 redef Kafka::topic_name = "";
 redef Kafka::kafka_conf = table(
 	["metadata.broker.list"] = "broker:29092"


### PR DESCRIPTION
This PR proposes:

- Replace the existing image for the zeek-streamer with a localbuild derived from the official `zeek/zeek:6.1.0`.  This upgrades the existing Zeek 3.1.1 to 6.1.0.
- Replaces the archived project for the Kafka Zeek plugin, which is archived and the parent project Metron is now in the Apache Attic, with a currently maintained version.
- Use the newer `zkg` tool to install the Kafka plugin.

Build using:

```
docker-compose -f docker-compose.yml -f kafka-connect/submit-connectors.yml up --build -d
```