### PR TITLE
Pinned the splunk image to 8.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
       KIBANA_AUTOCOMPLETETERMINATEAFTER: 2500000
 
   splunk:
-    image: splunk/splunk:latest
+    image: splunk/splunk:8.2.1
     depends_on:
       broker:
         condition: service_healthy


### PR DESCRIPTION
This will help with stability of the demo and the token is failing with the most recent versions.